### PR TITLE
Sampling events

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The harder you work the .NET core runtime, the more events it generates. Event g
 
 ### Sampling
 To counteract some of the performance impacts of measuring .NET core runtime events, sampling can be configured on supported collectors:
-```
+```csharp
 IDisposable collector = DotNetRuntimeStatsBuilder.Customize()
 	// Only 1 in 10 contention events will be sampled 
 	.WithContentionStats(sampleRate: SampleEvery.TenEvents)
@@ -65,11 +65,12 @@ IDisposable collector = DotNetRuntimeStatsBuilder.Customize()
 ```
 
 The default sample rates are listed below:
-Event collector                | Default sample rate
------------------------------- | -------------------
-`ThreadPoolSchedulingStats`    | `SampleEvery.TenEvents`
-`JitStats`				       | `SampleEvery.TenEvents`
-`ContentionStats`			   | `SampleEvery.TwoEvents`
+
+| Event collector                | Default sample rate     |
+| ------------------------------ | ------------------------|
+| `ThreadPoolSchedulingStats`    | `SampleEvery.TenEvents` |
+| `JitStats`                     | `SampleEvery.TenEvents` |
+| `ContentionStats`              | `SampleEvery.TwoEvents` |
 
 While the default sampling rates provide a decent balance between accuracy and resource consumption if you're concerned with the accuracy of metrics at all costs, 
 then feel free to change the sampling rate to `SampleEvery.OneEvent`. If minimal resource consumption (especially memory), is your goal you might like to 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ These metrics are essential for understanding the peformance of any non-trivial 
 Add the packge from [nuget](https://www.nuget.org/packages/prometheus-net.DotNetRuntime):
 ```powershell
 # If you're using v2 of prometheus-net
-dotnet add package prometheus-net.DotNetRuntime --version 2.0.8-beta
+dotnet add package prometheus-net.DotNetRuntime --version 2.1.0-beta
 
 # If you're using v3 of prometheus-net
-dotnet add package prometheus-net.DotNetRuntime --version 3.0.8-beta
+dotnet add package prometheus-net.DotNetRuntime --version 3.1.0-beta
 ```
 
 And then start the collector:
@@ -49,7 +49,32 @@ The metrics exposed can drive a rich dashboard, giving you a graphical insight i
 The harder you work the .NET core runtime, the more events it generates. Event generation and processing costs can stack up, especially around these types of events:
 - **JIT stats**: each method compiled by the JIT compiler emits two events. Most JIT compilation is performed at startup and depending on the size of your application, this could impact your startup performance.
 - **GC stats**: every 100KB of allocations, an event is emitted. If you are consistently allocating memory at a rate > 1GB/sec, you might like to disable GC stats.
-- **.NET thread pool scheduling stats**: For every work item scheduled on the thread pool, two events are emitted. If you are scheduling thousands of items per second on the thread pool, you might like to disable scheduling events.
+- **.NET thread pool scheduling stats**: For every work item scheduled on the thread pool, two events are emitted. If you are scheduling thousands of items per second on the thread pool, you might like to disable scheduling events or decrease the sampling rate of these events.
+
+### Sampling
+To counteract some of the performance impacts of measuring .NET core runtime events, sampling can be configured on supported collectors:
+```
+IDisposable collector = DotNetRuntimeStatsBuilder.Customize()
+	// Only 1 in 10 contention events will be sampled 
+	.WithContentionStats(sampleRate: SampleEvery.TenEvents)
+	// Only 1 in 100 JIT events will be sampled
+	.WithJitStats(sampleRate: SampleEvery.HundredEvents)
+	// Every event will be sampled (disables sampling)
+	.WithThreadPoolSchedulingStats(sampleRate: SampleEvery.OneEvent)
+	.StartCollecting();
+```
+
+The default sample rates are listed below:
+Event collector                | Default sample rate
+------------------------------ | -------------------
+`ThreadPoolSchedulingStats`    | `SampleEvery.TenEvents`
+`JitStats`				       | `SampleEvery.TenEvents`
+`ContentionStats`			   | `SampleEvery.TwoEvents`
+
+While the default sampling rates provide a decent balance between accuracy and resource consumption if you're concerned with the accuracy of metrics at all costs, 
+then feel free to change the sampling rate to `SampleEvery.OneEvent`. If minimal resource consumption (especially memory), is your goal you might like to 
+reduce the sampling rate.
+
 
 ## Further reading 
 - The mechanism for listening to runtime events is outlined in the [.NET core 2.2 release notes](https://docs.microsoft.com/en-us/dotnet/core/whats-new/dotnet-core-2-2#core).

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -79,12 +79,7 @@ namespace Benchmarks
             {
                 eventArgs = (EventWrittenEventArgs)Activator.CreateInstance(typeof(EventWrittenEventArgs), BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.CreateInstance, (Binder) null, new object[] {null}, null);
             }
-            [Benchmark]
-            public bool TestEvent()
-            {
-                return timer.TryGetEventPairDuration(eventArgs, out var duration);
-            }
-
+          
         }
     }
 }

--- a/src/Benchmarks/Program.cs
+++ b/src/Benchmarks/Program.cs
@@ -71,7 +71,7 @@ namespace Benchmarks
             [MethodImpl(MethodImplOptions.NoOptimization)]
             public long TestInterlockedIncLong() => Interlocked.Increment(ref l1);
 	
-            private EventPairTimer<int> timer = new EventPairTimer<int>(1, 2, x => x.EventId);
+            private EventPairTimer<int> timer = new EventPairTimer<int>(1, 2, x => x.EventId, SampleEvery.OneEvent);
 
             private EventWrittenEventArgs eventArgs;
 

--- a/src/prometheus-net.DotNetRuntime.Tests/DotNetRuntimeStatsBuilderTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/DotNetRuntimeStatsBuilderTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
 using NUnit.Framework;

--- a/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ContentionStatsCollectorTests.cs
@@ -12,7 +12,7 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
     {
         protected override ContentionStatsCollector CreateStatsCollector()
         {
-            return new ContentionStatsCollector();
+            return new ContentionStatsCollector(SampleEvery.OneEvent);
         }
         
         [Test]

--- a/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/GcStatsCollectorTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/GcStatsCollectorTests.cs
@@ -99,8 +99,12 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
                     if (val > 0)
                         return val;
                     
-                    // To improve the reliability of the test, call UpdateMetrics here. Why? Process.TotalProcessorTime isn't very precise and this
+                    // To improve the reliability of the test, do some CPU busy work + call UpdateMetrics here. Why? Process.TotalProcessorTime isn't very precise and this
                     // can lead to CpuRation believing that no CPU has been consumed
+                    for (int i = 0; i < 10_000; i++)
+                    {
+                    }
+
                     StatsCollector.UpdateMetrics();
 
                     return 0;

--- a/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ThreadPoolSchedulingStatsCollectorTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/IntegrationTests/ThreadPoolSchedulingStatsCollectorTests.cs
@@ -4,11 +4,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Prometheus.DotNetRuntime.StatsCollectors;
+using Prometheus.DotNetRuntime.StatsCollectors.Util;
 
 namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
 {
     [TestFixture]
-    internal class ThreadPoolSchedulingStatsCollectorTests : StatsCollectorIntegrationTestBase<ThreadPoolSchedulingStatsCollector>
+    internal class Given_A_ThreadPoolSchedulingStatsCollector_That_Samples_Every_Event : StatsCollectorIntegrationTestBase<ThreadPoolSchedulingStatsCollector>
     {
         protected override ThreadPoolSchedulingStatsCollector CreateStatsCollector()
         {
@@ -31,6 +32,37 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.IntegrationTests
             
             Assert.That(() => StatsCollector.ScheduledCount.Value, Is.GreaterThanOrEqualTo(1).After(100, 10));
             Assert.That(StatsCollector.ScheduleDelay.CollectAllCountValues().Single(), Is.GreaterThanOrEqualTo(1));
+            Assert.That(StatsCollector.ScheduleDelay.CollectAllSumValues().Single(), Is.EqualTo(sp.Elapsed.TotalSeconds).Within(0.01));
+        }
+    }
+    
+    [TestFixture]
+    internal class Given_A_ThreadPoolSchedulingStatsCollector_That_Samples_Fifth_Event : StatsCollectorIntegrationTestBase<ThreadPoolSchedulingStatsCollector>
+    {
+        protected override ThreadPoolSchedulingStatsCollector CreateStatsCollector()
+        {
+            return new ThreadPoolSchedulingStatsCollector(Constants.DefaultHistogramBuckets, SampleEvery.FiveEvents);
+        }
+
+        [Test]
+        public async Task When_many_items_of_work_is_queued_on_the_thread_pool_then_the_queued_and_scheduled_work_is_measured()
+        {
+            Assert.That(StatsCollector.ScheduledCount.Value, Is.EqualTo(0));
+            
+            // act (Task.Run will execute the function on the thread pool)
+            // There seems to be either a bug in the implementation of .NET core or a bug in my understanding...
+            // First call to Task.Run triggers a queued event but not a queue event. For now, call twice 
+            await Task.Run(() => 1 );
+
+            var sp = Stopwatch.StartNew();
+            for (int i = 0; i < 100; i++)
+            {
+                sp.Start();
+                await Task.Run(() => sp.Stop());
+            }
+
+            Assert.That(() => StatsCollector.ScheduledCount.Value, Is.GreaterThanOrEqualTo(100).After(100, 10));
+            Assert.That(StatsCollector.ScheduleDelay.CollectAllCountValues().Single(), Is.GreaterThanOrEqualTo(100));
             Assert.That(StatsCollector.ScheduleDelay.CollectAllSumValues().Single(), Is.EqualTo(sp.Elapsed.TotalSeconds).Within(0.01));
         }
     }

--- a/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/Util/EventPairTimerTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/Util/EventPairTimerTests.cs
@@ -23,7 +23,7 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
         public void TryGetEventPairDuration_ignores_events_that_its_not_configured_to_look_for()
         {
             var nonMonitoredEvent = CreateEventWrittenEventArgs(3);
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(nonMonitoredEvent, out var duration), Is.False);
+            Assert.That(_eventPairTimer.TryGetDuration(nonMonitoredEvent, out var duration), Is.EqualTo(DurationResult.Unrecognized));
             Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
         }
         
@@ -31,7 +31,7 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
         public void TryGetEventPairDuration_ignores_end_events_if_it_never_saw_the_start_event()
         {
             var nonMonitoredEvent = CreateEventWrittenEventArgs(EventIdEnd, payload: 1L);
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(nonMonitoredEvent, out var duration), Is.False);
+            Assert.That(_eventPairTimer.TryGetDuration(nonMonitoredEvent, out var duration),Is.EqualTo(DurationResult.FinalWithoutDuration));
             Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
         }
         
@@ -41,11 +41,11 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
             // arrange
             var now = DateTime.UtcNow;
             var startEvent = CreateEventWrittenEventArgs(EventIdStart, now, payload: 1L);
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(startEvent, out var _), Is.False);
+            Assert.That(_eventPairTimer.TryGetDuration(startEvent, out var _), Is.EqualTo(DurationResult.Start));
             var endEvent = CreateEventWrittenEventArgs(EventIdEnd, now.AddMilliseconds(100), payload: 1L);
             
             // act
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(endEvent, out var duration), Is.True);
+            Assert.That(_eventPairTimer.TryGetDuration(endEvent, out var duration), Is.EqualTo(DurationResult.FinalWithDuration));
             Assert.That(duration.TotalMilliseconds, Is.EqualTo(100));
         }
         
@@ -55,11 +55,11 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
             // arrange
             var now = DateTime.UtcNow;
             var startEvent = CreateEventWrittenEventArgs(EventIdStart, now, payload: 1L);
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(startEvent, out var _), Is.False);
+            Assert.That(_eventPairTimer.TryGetDuration(startEvent, out var _), Is.EqualTo(DurationResult.Start));
             var endEvent = CreateEventWrittenEventArgs(EventIdEnd, now, payload: 1L);
             
             // act
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(endEvent, out var duration), Is.True);
+            Assert.That(_eventPairTimer.TryGetDuration(endEvent, out var duration), Is.EqualTo(DurationResult.FinalWithDuration));
             Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
         }
         
@@ -75,14 +75,14 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
             var startEvent3 = CreateEventWrittenEventArgs(EventIdStart, now, payload: 3L);
             var endEvent3 = CreateEventWrittenEventArgs(EventIdEnd, now.AddMilliseconds(100), payload: 3L);
 
-            _eventPairTimer.TryGetEventPairDuration(startEvent1, out var _);
-            _eventPairTimer.TryGetEventPairDuration(startEvent2, out var _);
-            _eventPairTimer.TryGetEventPairDuration(startEvent3, out var _);
+            _eventPairTimer.TryGetDuration(startEvent1, out var _);
+            _eventPairTimer.TryGetDuration(startEvent2, out var _);
+            _eventPairTimer.TryGetDuration(startEvent3, out var _);
             
             // act
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(endEvent3, out var event3Duration), Is.True);
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(endEvent2, out var event2Duration), Is.True);
-            Assert.That(_eventPairTimer.TryGetEventPairDuration(endEvent1, out var event1Duration), Is.True);
+            Assert.That(_eventPairTimer.TryGetDuration(endEvent3, out var event3Duration), Is.EqualTo(DurationResult.FinalWithDuration));
+            Assert.That(_eventPairTimer.TryGetDuration(endEvent2, out var event2Duration), Is.EqualTo(DurationResult.FinalWithDuration));
+            Assert.That(_eventPairTimer.TryGetDuration(endEvent1, out var event1Duration), Is.EqualTo(DurationResult.FinalWithDuration));
             
             Assert.That(event1Duration.TotalMilliseconds, Is.EqualTo(300));
             Assert.That(event2Duration.TotalMilliseconds, Is.EqualTo(200));

--- a/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/Util/Given_An_EventPairTimer_That_Samples_Every_Event.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/Util/Given_An_EventPairTimer_That_Samples_Every_Event.cs
@@ -8,7 +8,7 @@ using Fasterflect;
 namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
 {
     [TestFixture]
-    public class EventPairTimerTests
+    public class Given_An_EventPairTimer_That_Samples_Every_Event : EventPairTimerBaseClass
     {
         private const int EventIdStart = 1, EventIdEnd = 2;
         private EventPairTimer<long> _eventPairTimer;
@@ -16,7 +16,7 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
         [SetUp]
         public void SetUp()
         {
-            _eventPairTimer = new EventPairTimer<long>(EventIdStart, EventIdEnd, x => (long)x.Payload[0]);
+            _eventPairTimer = new EventPairTimer<long>(EventIdStart, EventIdEnd, x => (long)x.Payload[0], SampleEvery.OneEvent);
         }
 
         [Test]
@@ -88,8 +88,54 @@ namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
             Assert.That(event2Duration.TotalMilliseconds, Is.EqualTo(200));
             Assert.That(event3Duration.TotalMilliseconds, Is.EqualTo(100));
         }
+    }
 
-        private EventWrittenEventArgs CreateEventWrittenEventArgs(int eventId, DateTime? timestamp = null, params object[] payload)
+
+    [TestFixture]
+    public class Given_An_EventPairTimer_That_Samples_Every_2nd_Event : EventPairTimerBaseClass
+    {
+        
+        private EventPairTimer<long> _eventPairTimer;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _eventPairTimer = new EventPairTimer<long>(EventIdStart, EventIdEnd, x => (long)x.Payload[0], SampleEvery.TwoEvents);
+        }
+
+        [Test]
+        public void TryGetEventPairDuration_recognizes_start_events_that_will_be_discarded()
+        {
+            var startEvent1 = CreateEventWrittenEventArgs(EventIdStart, DateTime.UtcNow, payload: 1L);
+            Assert.That(_eventPairTimer.TryGetDuration(startEvent1, out var duration),Is.EqualTo(DurationResult.Start));
+            Assert.That(duration, Is.EqualTo(TimeSpan.Zero));
+        }
+        
+        [Test]
+        public void TryGetEventPairDuration_will_discard_1_event_and_calculate_duration_for_the_2nd_event()
+        {
+            // arrange
+            var now = DateTime.UtcNow;
+            var startEvent1 = CreateEventWrittenEventArgs(EventIdStart, now, payload: 1L);
+            var endEvent1 = CreateEventWrittenEventArgs(EventIdEnd, now.AddMilliseconds(300), payload: 1L);
+            var startEvent2 = CreateEventWrittenEventArgs(EventIdStart, now, payload: 2L);
+            var endEvent2 = CreateEventWrittenEventArgs(EventIdEnd, now.AddMilliseconds(200), payload: 2L);
+
+            _eventPairTimer.TryGetDuration(startEvent1, out var _);
+            _eventPairTimer.TryGetDuration(startEvent2, out var _);
+            
+            // act
+            Assert.That(_eventPairTimer.TryGetDuration(endEvent1, out var _), Is.EqualTo(DurationResult.FinalWithoutDuration));
+            Assert.That(_eventPairTimer.TryGetDuration(endEvent2, out var _), Is.EqualTo(DurationResult.FinalWithDuration));
+        }
+
+    }
+
+    public class EventPairTimerBaseClass
+    {
+        protected const int EventIdStart = 1, EventIdEnd = 2;
+        
+        protected EventWrittenEventArgs CreateEventWrittenEventArgs(int eventId, DateTime? timestamp = null, params object[] payload)
         {
             var args = (EventWrittenEventArgs)typeof(EventWrittenEventArgs).CreateInstance(new []{ typeof(EventSource)}, Flags.NonPublic | Flags.Instance, new object[] { null});
             args.SetPropertyValue("EventId", eventId);

--- a/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/Util/SamplingRateTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/StatsCollectors/Util/SamplingRateTests.cs
@@ -1,0 +1,48 @@
+using System;
+using NUnit.Framework;
+using Prometheus.DotNetRuntime.StatsCollectors.Util;
+
+namespace Prometheus.DotNetRuntime.Tests.StatsCollectors.Util
+{
+    [TestFixture]
+    public class SamplingRateTests
+    {
+        [Test]
+        [TestCase(SampleEvery.OneEvent, 1)]
+        [TestCase(SampleEvery.TwoEvents, 2)]
+        [TestCase(SampleEvery.FiveEvents, 5)]
+        [TestCase(SampleEvery.TenEvents, 10)]
+        [TestCase(SampleEvery.TwentyEvents, 20)]
+        [TestCase(SampleEvery.FiftyEvents, 50)]
+        [TestCase(SampleEvery.HundredEvents, 100)]
+        public void SampleEvery_Reflects_The_Ratio_Of_Every_100_Events_That_Will_Be_Sampled(SampleEvery samplingRate, int expected)
+        {
+            var sr = new SamplingRate(samplingRate);
+            Assert.That(sr.SampleEvery, Is.EqualTo(expected));
+        }
+
+        [Test]
+        [TestCase(SampleEvery.OneEvent, 1000)]
+        [TestCase(SampleEvery.TwoEvents, 500)]
+        [TestCase(SampleEvery.FiveEvents, 200)]
+        [TestCase(SampleEvery.TenEvents, 100)]
+        [TestCase(SampleEvery.TwentyEvents, 50)]
+        [TestCase(SampleEvery.FiftyEvents, 20)]
+        [TestCase(SampleEvery.HundredEvents, 10)]
+        public void Given_1000_Events_ShouldSampleEvent_Returns_True_Every_Nth_Event(SampleEvery samplingRate, int expectedEvents)
+        {
+            var eventsSampled = 0;
+            var sr = new SamplingRate(samplingRate);
+            
+            for (int i = 0; i < 1_000; i++)
+            {
+                if (sr.ShouldSampleEvent())
+                {
+                    eventsSampled++;
+                }
+            }
+            
+            Assert.That(eventsSampled, Is.EqualTo(expectedEvents));
+        }
+    }
+}

--- a/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
+++ b/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
@@ -69,15 +69,20 @@ namespace Prometheus.DotNetRuntime
                 return runtimeStatsCollector;
             }
 
-
             /// <summary>
             /// Include metrics around the volume of work scheduled on the worker thread pool
             /// and the scheduling delays.
             /// </summary>
             /// <param name="histogramBuckets">Buckets for the scheduling delay histogram</param>
-            public Builder WithThreadPoolSchedulingStats(double[] histogramBuckets = null)
+            /// <param name="sampleRate">
+            /// The sampling rate for thread pool scheduling events. A lower sampling rate reduces memory use
+            /// but reduces the accuracy of metrics produced (as a percentage of events are discarded).
+            /// If your application achieves a high level of throughput (thousands of work items scheduled per second on
+            /// the thread pool), it's recommend to reduce the sampling rate even further.
+            /// </param>
+            public Builder WithThreadPoolSchedulingStats(double[] histogramBuckets = null, SampleEvery sampleRate = SampleEvery.TenEvents)
             {
-                StatsCollectors.Add(new ThreadPoolSchedulingStatsCollector(histogramBuckets ?? Constants.DefaultHistogramBuckets));
+                StatsCollectors.Add(new ThreadPoolSchedulingStatsCollector(histogramBuckets ?? Constants.DefaultHistogramBuckets, sampleRate));
                 return this;
             }
 
@@ -94,9 +99,13 @@ namespace Prometheus.DotNetRuntime
             /// <summary>
             /// Include metrics around volume of locks contended.
             /// </summary>
-            public Builder WithContentionStats()
+            /// <param name="sampleRate">
+            /// The sampling rate for contention events (defaults to 100%). A lower sampling rate reduces memory use
+            /// but reduces the accuracy of metrics produced (as a percentage of events are discarded).
+            /// </param>
+            public Builder WithContentionStats(SampleEvery sampleRate = SampleEvery.TwoEvents)
             {
-                StatsCollectors.Add(new ContentionStatsCollector());
+                StatsCollectors.Add(new ContentionStatsCollector(sampleRate));
                 return this;
             }
             
@@ -104,9 +113,15 @@ namespace Prometheus.DotNetRuntime
             /// Include metrics summarizing the volume of methods being compiled
             /// by the Just-In-Time compiler.
             /// </summary>
-            public Builder WithJitStats()
+            /// <param name="sampleRate">
+            /// The sampling rate for JIT events. A lower sampling rate reduces memory use
+            /// but reduces the accuracy of metrics produced (as a percentage of events are discarded).
+            /// If your application achieves a high level of throughput (thousands of work items scheduled per second on
+            /// the thread pool), it's recommend to reduce the sampling rate even further.
+            /// </param>
+            public Builder WithJitStats(SampleEvery sampleRate = SampleEvery.TenEvents)
             {
-                StatsCollectors.Add(new JitStatsCollector());
+                StatsCollectors.Add(new JitStatsCollector(sampleRate));
                 return this;
             }
             

--- a/src/prometheus-net.DotNetRuntime/MetricExtensions.cs
+++ b/src/prometheus-net.DotNetRuntime/MetricExtensions.cs
@@ -3,12 +3,11 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-
 #if PROMV2
 using Prometheus.Advanced;
 using Prometheus.Advanced.DataContracts;
-#endif
 
+#endif
 
 namespace Prometheus.DotNetRuntime
 {
@@ -29,7 +28,7 @@ namespace Prometheus.DotNetRuntime
         {
             return CollectAllMetrics(counter, excludeUnlabeled).Select(x => x.counter.value);
         }
-        
+
         /// <summary>
         /// Collects all sum values of a histogram recorded across both unlabeled and labeled metrics.
         /// </summary>
@@ -37,7 +36,7 @@ namespace Prometheus.DotNetRuntime
         {
             return CollectAllMetrics(histogram, excludeUnlabeled).Select(x => x.histogram.sample_sum);
         }
-        
+
         /// <summary>
         /// Collects all count values of a histogram recorded across both unlabeled and labeled metrics.
         /// </summary>
@@ -45,10 +44,17 @@ namespace Prometheus.DotNetRuntime
         {
             return CollectAllMetrics(histogram).Select(x => x.histogram.sample_count);
         }
-        
+
         internal static IEnumerable<Metric> CollectAllMetrics(this ICollector collector, bool excludeUnlabeled = false)
         {
             return collector.Collect().Single().metric.Where(x => !excludeUnlabeled || x.label.Count > 0);
+        }
+
+        internal static void Observe(this Histogram h, double val, int samples)
+        {
+            // Ugly hack for V2 :(
+            for (int i = 0; i < samples; i++)
+                h.Observe(val);
         }
 #endif
 

--- a/src/prometheus-net.DotNetRuntime/SampleRate.cs
+++ b/src/prometheus-net.DotNetRuntime/SampleRate.cs
@@ -1,0 +1,23 @@
+namespace Prometheus.DotNetRuntime
+{
+    /// <summary>
+    /// Determines the level of sampling stats collectors will perform. <see cref="OneEvent"/> offers the highest level
+    /// of accuracy while <see cref="HundredEvents"/> offers the lowest level of precision but least amount of overhead.
+    /// </summary>
+    public enum SampleEvery
+    {
+        /// <summary>
+        /// The highest level of accuracy- every event will be sampled.
+        /// </summary>
+        OneEvent = 1,
+        TwoEvents = 2,
+        FiveEvents = 5,
+        TenEvents = 10,
+        TwentyEvents = 20,
+        FiftyEvents = 50,
+        /// <summary>
+        /// The lowest level of precision- only 1 in 100 events will be sampled.
+        /// </summary>
+        HundredEvents = 100
+    }
+}

--- a/src/prometheus-net.DotNetRuntime/StatsCollectors/ContentionStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/StatsCollectors/ContentionStatsCollector.cs
@@ -40,7 +40,7 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
 
         public void ProcessEvent(EventWrittenEventArgs e)
         {
-            if (_eventPairTimer.TryGetEventPairDuration(e, out var duration))
+            if (_eventPairTimer.TryGetDuration(e, out var duration) == DurationResult.FinalWithDuration)
             {
                 ContentionTotal.Inc();
                 ContentionSecondsTotal.Inc(duration.TotalSeconds);    

--- a/src/prometheus-net.DotNetRuntime/StatsCollectors/ContentionStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/StatsCollectors/ContentionStatsCollector.cs
@@ -18,8 +18,20 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
     /// </remarks>
     internal sealed class ContentionStatsCollector : IEventSourceStatsCollector
     {
+        private readonly SamplingRate _samplingRate;
         private const int EventIdContentionStart = 81, EventIdContentionStop = 91;
-        private readonly EventPairTimer<long> _eventPairTimer = new EventPairTimer<long>(EventIdContentionStart, EventIdContentionStop, x => x.OSThreadId);
+        private readonly EventPairTimer<long> _eventPairTimer; 
+
+        public ContentionStatsCollector(SamplingRate samplingRate)
+        {
+            _samplingRate = samplingRate;
+            _eventPairTimer = new EventPairTimer<long>(
+                EventIdContentionStart, 
+                EventIdContentionStop, 
+                x => x.OSThreadId, 
+                samplingRate
+            );
+        }
         
         public EventKeywords Keywords => (EventKeywords) DotNetRuntimeEventSource.Keywords.Contention;
         public EventLevel Level => EventLevel.Informational;
@@ -42,8 +54,8 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
         {
             if (_eventPairTimer.TryGetDuration(e, out var duration) == DurationResult.FinalWithDuration)
             {
-                ContentionTotal.Inc();
-                ContentionSecondsTotal.Inc(duration.TotalSeconds);    
+                ContentionTotal.Inc(_samplingRate.SampleEvery);
+                ContentionSecondsTotal.Inc(duration.TotalSeconds * _samplingRate.SampleEvery);    
             }
         }
     }

--- a/src/prometheus-net.DotNetRuntime/StatsCollectors/GcStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/StatsCollectors/GcStatsCollector.cs
@@ -33,13 +33,15 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
             EventIdGcStart,
             EventIdGcStop,
             x => (uint) x.Payload[0],
-            x => new GcData((uint) x.Payload[1], (DotNetRuntimeEventSource.GCType) x.Payload[3]));
+            x => new GcData((uint) x.Payload[1], (DotNetRuntimeEventSource.GCType) x.Payload[3]),
+            SampleEvery.OneEvent);
 
         private readonly EventPairTimer<int> _gcPauseEventTimer = new EventPairTimer<int>(
             EventIdSuspendEEStart,
             EventIdRestartEEStop,
             // Suspensions/ Resumptions are always done sequentially so there is no common value to match events on. Return a constant value as the event id.
-            x => 1);
+            x => 1,
+            SampleEvery.OneEvent);
 
         private readonly Dictionary<DotNetRuntimeEventSource.GCReason, string> _gcReasonToLabels = LabelGenerator.MapEnumToLabelValues<DotNetRuntimeEventSource.GCReason>();
         private readonly Ratio _gcCpuRatio = Ratio.ProcessTotalCpu();

--- a/src/prometheus-net.DotNetRuntime/StatsCollectors/GcStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/StatsCollectors/GcStatsCollector.cs
@@ -148,7 +148,7 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
                 return;
             }
 
-            if (_gcPauseEventTimer.TryGetEventPairDuration(e, out var pauseDuration))
+            if (_gcPauseEventTimer.TryGetDuration(e, out var pauseDuration) == DurationResult.FinalWithDuration)
             {
                 GcPauseSeconds.Observe(pauseDuration.TotalSeconds);
                 return;
@@ -159,7 +159,7 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
                 GcCollectionReasons.Labels(_gcReasonToLabels[(DotNetRuntimeEventSource.GCReason) e.Payload[2]]).Inc();
             }
 
-            if (_gcEventTimer.TryGetEventPairDuration(e, out var gcDuration, out var gcData))
+            if (_gcEventTimer.TryGetDuration(e, out var gcDuration, out var gcData) == DurationResult.FinalWithDuration)
             {
                 GcCollectionSeconds.Labels(gcData.GetGenerationToString(), gcData.GetTypeToString()).Observe(gcDuration.TotalSeconds);
             }

--- a/src/prometheus-net.DotNetRuntime/StatsCollectors/JitStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/StatsCollectors/JitStatsCollector.cs
@@ -50,7 +50,7 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
 
         public void ProcessEvent(EventWrittenEventArgs e)
         {
-            if (_eventPairTimer.TryGetEventPairDuration(e, out var duration))
+            if (_eventPairTimer.TryGetDuration(e, out var duration) == DurationResult.FinalWithDuration)
             {
                 // dynamic methods are of special interest to us- only a certain number of JIT'd dynamic methods
                 // will be cached. Frequent use of dynamic can cause methods to be evicted from the cache and re-JIT'd

--- a/src/prometheus-net.DotNetRuntime/StatsCollectors/ThreadPoolSchedulingStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/StatsCollectors/ThreadPoolSchedulingStatsCollector.cs
@@ -64,9 +64,9 @@ namespace Prometheus.DotNetRuntime.StatsCollectors
                 ScheduledCount.Inc();
             }
             
-            if (_eventPairTimer.TryGetEventPairDuration(e, out var duration))
+            if (_eventPairTimer.TryGetDuration(e, out var duration) == DurationResult.FinalWithDuration)
             {
-                ScheduleDelay.Observe(duration.TotalSeconds);
+                ScheduleDelay.Observe(duration.TotalSeconds); // x 99?
             }   
         }
     }

--- a/src/prometheus-net.DotNetRuntime/StatsCollectors/Util/SamplingRate.cs
+++ b/src/prometheus-net.DotNetRuntime/StatsCollectors/Util/SamplingRate.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading;
+
+namespace Prometheus.DotNetRuntime.StatsCollectors.Util
+{
+    /// <summary>
+    /// The rate at which high-frequency events are sampled
+    /// </summary>
+    /// <remarks>
+    /// In busy .NET applications, certain events are emitted at the rate of thousands/ tens of thousands per second.
+    /// To track all the start and end pairs of events for these events can consume a significant amount of memory (100+ MB).
+    /// Using a sampling rate allows us to reduce the memory requirements. 
+    /// </remarks>
+    public sealed class SamplingRate
+    {
+        private long _next;
+        
+        public SamplingRate(SampleEvery every)
+        {
+            SampleEvery = (int)every;
+            _next = 0L;
+        }
+        
+        /// <summary>
+        /// Out of every 100 events, how many events we should observe.
+        /// </summary>
+        public int SampleEvery { get; }
+
+        /// <summary>
+        /// Determines if we should sample a given event.
+        /// </summary>
+        /// <returns></returns>
+        public bool ShouldSampleEvent()
+        {
+            if (SampleEvery == 1)
+                return true;
+            
+            return (Interlocked.Increment(ref _next) % SampleEvery) == 0;
+        }
+        
+        public static implicit operator SamplingRate(SampleEvery d) => new SamplingRate(d);
+    }
+}

--- a/src/prometheus-net.DotNetRuntime/prometheus-net.DotNetRuntime.csproj
+++ b/src/prometheus-net.DotNetRuntime/prometheus-net.DotNetRuntime.csproj
@@ -15,7 +15,7 @@
         <RootNamespace>Prometheus.DotNetRuntime</RootNamespace>
         <AssemblyName>prometheus-net.DotNetRuntime</AssemblyName>
         <PackageId>prometheus-net.DotNetRuntime</PackageId>
-        <Version>$(PromMajorVersion).0.9-beta</Version>
+        <Version>$(PromMajorVersion).1.0-beta</Version>
         <Authors>James Luck</Authors>
         <PackageTags>Prometheus prometheus-net IOnDemandCollector runtime metrics gc jit threadpool contention stats</PackageTags>
         <PackageProjectUrl>https://github.com/djluck/prometheus-net.DotNetRuntime</PackageProjectUrl>


### PR DESCRIPTION
# Summary  …
Added event sampling for high throughput stats collectors to reduce memory footprint, should hopefully resolve issue #6.

# Changes
- `JitStatsCollector`, `ThreadPoolSchedulingStatsCollector` and `ContentionStatsCollector` can now be configured to discard a ratio of start/ stop events, reducing the number of events we need to store in a `Cache` at any one time
- A new default sampling rate has been configured for the above collectors (see README)
- Updated README with example on how to configure sampling and details of the defaults for each stats collector