### PR TITLE
Providing a way to add stats to non-default registry

### DIFF
--- a/src/prometheus-net.DotNetRuntime.Tests/DotNetRuntimeStatsBuilderTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/DotNetRuntimeStatsBuilderTests.cs
@@ -73,5 +73,27 @@ namespace Prometheus.DotNetRuntime.Tests
             {
             }
         }
+
+        [Test]
+        public void StartCollecting_Allows_Multiple_Collectors_For_Non_Default_Registries()
+        {
+#if PROMV2
+            var registry1 = new DefaultCollectorRegistry();
+            var registry2 = new DefaultCollectorRegistry();
+#elif PROMV3
+            var registry1 = Metrics.NewCustomRegistry();
+            var registry2 = Metrics.NewCustomRegistry();
+#endif
+
+            using (DotNetRuntimeStatsBuilder.Customize().StartCollecting())
+            {
+                using (DotNetRuntimeStatsBuilder.Customize().StartCollecting(registry1))
+                {
+                    using (DotNetRuntimeStatsBuilder.Customize().StartCollecting(registry2))
+                    {
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
+++ b/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
@@ -5,9 +5,6 @@ using System.Diagnostics.Tracing;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Runtime.Versioning;
-#if PROMV2
-using Prometheus.Advanced;
-#endif
 using Prometheus.DotNetRuntime.StatsCollectors;
 using Prometheus.DotNetRuntime.StatsCollectors.Util;
 #if PROMV2
@@ -65,9 +62,9 @@ namespace Prometheus.DotNetRuntime
             public IDisposable StartCollecting()
             {
 #if PROMV2
-                return StartCollecting(TCollectorRegistry.Instance, registryIsDefault: true);
+                return StartCollecting(TCollectorRegistry.Instance);
 #elif PROMV3
-                return StartCollecting(Metrics.DefaultRegistry, registryIsDefault: true);
+                return StartCollecting(Metrics.DefaultRegistry);
 #endif
             }
 
@@ -79,17 +76,7 @@ namespace Prometheus.DotNetRuntime
             /// <returns></returns>
             public IDisposable StartCollecting(TCollectorRegistry registry)
             {
-                return StartCollecting(registry, registryIsDefault: false);
-            }
-
-            private IDisposable StartCollecting(TCollectorRegistry registry, bool registryIsDefault)
-            {
-                if (registryIsDefault && DotNetRuntimeStatsCollector.Instance != null)
-                {
-                    throw new InvalidOperationException(".NET runtime metrics are already being collected. Dispose() of your previous collector before calling this method again.");
-                }
-
-                var runtimeStatsCollector = new DotNetRuntimeStatsCollector(StatsCollectors.ToImmutableHashSet(), _errorHandler, _debugMetrics, isDefaultInstance: registryIsDefault);
+                var runtimeStatsCollector = new DotNetRuntimeStatsCollector(StatsCollectors.ToImmutableHashSet(), _errorHandler, _debugMetrics, registry);
 #if PROMV2
                 registry.RegisterOnDemandCollectors(runtimeStatsCollector);
 #elif PROMV3

--- a/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsCollector.cs
@@ -19,13 +19,18 @@ namespace Prometheus.DotNetRuntime
         private readonly ImmutableHashSet<IEventSourceStatsCollector> _statsCollectors;
         private readonly bool _enabledDebugging;
         private readonly Action<Exception> _errorHandler;
+        private readonly bool _isDefaultInstance;
 
-        internal DotNetRuntimeStatsCollector(ImmutableHashSet<IEventSourceStatsCollector> statsCollectors, Action<Exception> errorHandler, bool enabledDebugging)
+        internal DotNetRuntimeStatsCollector(ImmutableHashSet<IEventSourceStatsCollector> statsCollectors, Action<Exception> errorHandler, bool enabledDebugging, bool isDefaultInstance)
         {
             _statsCollectors = statsCollectors;
             _enabledDebugging = enabledDebugging;
             _errorHandler = errorHandler ?? (e => { });
-            Instance = this;
+            if (isDefaultInstance)
+            {
+                _isDefaultInstance = true;
+                Instance = this;
+            }
         }
         
         internal static DotNetRuntimeStatsCollector Instance { get; private set; }
@@ -83,7 +88,10 @@ namespace Prometheus.DotNetRuntime
             }
             finally
             {
-                Instance = null;
+                if (_isDefaultInstance)
+                {
+                    Instance = null;
+                }
             }
         }
     }


### PR DESCRIPTION
Needed if an application wants to expose multiple metrics endpoints, or if it is using a CollectionRegistry that has been created by an IoC container. 
