### PR TITLE
More performant DotNetEventListener.OnEventWritten

### DIFF
--- a/src/prometheus-net.DotNetRuntime/DotNetEventListener.cs
+++ b/src/prometheus-net.DotNetRuntime/DotNetEventListener.cs
@@ -1,10 +1,6 @@
 using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.Tracing;
-using System.Linq;
-using Prometheus.DotNetRuntime.StatsCollectors;
 using Prometheus.DotNetRuntime.StatsCollectors.Util;
 
 namespace Prometheus.DotNetRuntime
@@ -16,25 +12,27 @@ namespace Prometheus.DotNetRuntime
 
         private readonly IEventSourceStatsCollector _collector;
         private readonly Action<Exception> _errorHandler;
-        private readonly bool _enableDebugging;
+        private readonly Action<EventWrittenEventArgs> _processEvent;
         private readonly string _nameSnakeCase;
 
         internal DotNetEventListener(IEventSourceStatsCollector collector, Action<Exception> errorHandler, bool enableDebugging) : base()
         {
             _collector = collector;
             _errorHandler = errorHandler;
-            _enableDebugging = enableDebugging;
-            
-            if (_enableDebugging)
+
+            if (enableDebugging)
             {
                 _eventTypeCounts ??= Metrics.CreateCounter($"dotnet_debug_events_total", "The total number of .NET diagnostic events processed", "collector_name", "event_source_name", "event_name");
                 _cpuConsumed ??= Metrics.CreateCounter("dotnet_debug_cpu_seconds_total", "The total CPU time consumed by processing .NET diagnostic events (does not include the CPU cost to generate the events)", "collector_name", "event_source_name", "event_name");
                 _nameSnakeCase = collector.GetType().Name.ToSnakeCase();
+                _processEvent = ProcessEventWithDebugging;
             }
-            
+            else
+                _processEvent = ProcessEvent;
+
             EnableEventSources(collector);
         }
-        
+
         internal bool StartedReceivingEvents { get; private set; }
 
         private void EnableEventSources(IEventSourceStatsCollector forCollector)
@@ -49,30 +47,28 @@ namespace Prometheus.DotNetRuntime
                 }
             };
         }
-        
+
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            var sp = new Stopwatch();
             try
             {
-                if (_enableDebugging)
-                {
-                    _eventTypeCounts.Labels(_nameSnakeCase, eventData.EventSource.Name, eventData.EventName).Inc();
-                    sp.Restart();
-                }
-                
-                _collector.ProcessEvent(eventData);
-
-                if (_enableDebugging)
-                {
-                    sp.Stop();
-                    _cpuConsumed.Labels(_nameSnakeCase, eventData.EventSource.Name, eventData.EventName).Inc(sp.Elapsed.TotalSeconds);
-                }
+                _processEvent(eventData);
             }
             catch (Exception e)
             {
                 _errorHandler(e);
             }
+        }
+
+        private void ProcessEvent(EventWrittenEventArgs eventData) => _collector.ProcessEvent(eventData);
+
+        private void ProcessEventWithDebugging(EventWrittenEventArgs eventData)
+        {
+            _eventTypeCounts.Labels(_nameSnakeCase, eventData.EventSource.Name, eventData.EventName).Inc();
+            var stopWatch = Stopwatch.StartNew();
+            ProcessEvent(eventData);
+            stopWatch.Stop();
+            _cpuConsumed.Labels(_nameSnakeCase, eventData.EventSource.Name, eventData.EventName).Inc(stopWatch.Elapsed.TotalSeconds);
         }
     }
 }


### PR DESCRIPTION
Hi

Since this method is called a lot, I figured this small performance improvement would be worth doing :-)

| Method |     Mean |     Error |    StdDev | Rank |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------- |---------:|----------:|----------:|-----:|-------:|------:|------:|----------:|
|  Before | 6.373 ns | 0.2041 ns | 0.3681 ns |    2 | 0.0096 |     - |     - |      40 B |
| After | 1.886 ns | 0.0604 ns | 0.0536 ns |    1 |      - |     - |     - |         - |