### PR TITLE
Ensure we pass the `Version` property- this will both set the package…

### DIFF
--- a/.github/workflows/publish-nuget-packages.yaml
+++ b/.github/workflows/publish-nuget-packages.yaml
@@ -17,5 +17,5 @@ jobs:
         arrTag=(${GITHUB_REF//\// })
         VERSION="${arrTag[2]}"
         echo "Version: $VERSION"
-        dotnet pack src/prometheus-net.DotNetRuntime --include-symbols -c "Release" -p:PackageVersion=$VERSION  --output "build/"
+        dotnet pack src/prometheus-net.DotNetRuntime --include-symbols -c "Release" -p:Version=$VERSION  --output "build/"
         dotnet nuget push "build/prometheus-net.DotNetRuntime.*.symbols.nupkg" -k ${{ secrets.NUGET_API_KEY }} -s "https://api.nuget.org/v3/index.json" -n true


### PR DESCRIPTION
… metadata version and the assembly version.

Fixes https://github.com/djluck/prometheus-net.DotNetRuntime/issues/52.