### PR TITLE
Updated Microsoft.Extensions.DependencyInjection package reference version to accept >= 3

### DIFF
--- a/src/prometheus-net.DotNetRuntime/prometheus-net.DotNetRuntime.csproj
+++ b/src/prometheus-net.DotNetRuntime/prometheus-net.DotNetRuntime.csproj
@@ -30,6 +30,6 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
+      <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="[3,)" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
V4 added a reference to `Microsoft.Extensions.DependencyInjection` version `5.0.1`. The resulting nuget package requires this dependency as `>= 5.0.1`. 

This project also builds using v3, so I propose to loosen this dependency version requirement.