### PR TITLE
Add System.Net.NameResolution metrics

### DIFF
--- a/src/prometheus-net.DotNetRuntime.Tests/IntegrationTests/NameResolutionTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/IntegrationTests/NameResolutionTests.cs
@@ -1,0 +1,38 @@
+﻿using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Prometheus.DotNetRuntime.Metrics.Producers;
+
+namespace Prometheus.DotNetRuntime.Tests.IntegrationTests
+{
+    public class NameResolutionTests : IntegrationTestBase<NameResolutionMetricProducer>
+    {
+        [Test]
+        public async Task Given_a_DNS_lookup_metrics_should_increase()
+        {
+            // arrange
+            var initialLookups = MetricProducer.DnsLookups.Value;
+            var initialLookupDuration = MetricProducer.DnsLookupDuration.Sum;
+
+            // act
+            var lookups = Enumerable.Range(1, 10)
+                .Select(n => Dns.GetHostEntryAsync("localhost"))
+                .ToArray();
+
+            await Task.WhenAll(lookups);
+
+            // assert
+            Assert.That(() => MetricProducer.DnsLookups.Value, Is.GreaterThanOrEqualTo(initialLookups + 10).After(10_000, 100));
+            Assert.That(MetricProducer.DnsLookupDuration.Sum, Is.GreaterThan(initialLookupDuration));
+        }
+
+        protected override DotNetRuntimeStatsBuilder.Builder ConfigureBuilder(DotNetRuntimeStatsBuilder.Builder toConfigure)
+        {
+            // Do a DNS lookup to force creation of the NameResolution event source.
+            Dns.GetHostEntry("localhost");
+
+            return toConfigure.WithNameResolution();
+        }
+    }
+}

--- a/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
+++ b/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
@@ -31,7 +31,8 @@ namespace Prometheus.DotNetRuntime
                 .WithGcStats()
                 .WithJitStats()
                 .WithSocketStats()
-                .WithExceptionStats();
+                .WithExceptionStats()
+                .WithNameResolution();
         }
 
         /// <summary>
@@ -188,6 +189,18 @@ namespace Prometheus.DotNetRuntime
             {
                 ListenerRegistrations.AddOrReplace(ListenerRegistration.Create(CaptureLevel.Counters, sp => new SocketsEventParser()));
                 _services.TryAddSingletonEnumerable<IMetricProducer, SocketsMetricProducer>();
+
+                return this;
+            }
+
+            /// <summary>
+            /// Include metrics around DNS lookup requests and average duration.
+            /// </summary>
+            /// <returns></returns>
+            public Builder WithNameResolution()
+            {
+                ListenerRegistrations.AddOrReplace(ListenerRegistration.Create(CaptureLevel.Counters, sp => new NameResolutionEventParser()));
+                _services.TryAddSingletonEnumerable<IMetricProducer, NameResolutionMetricProducer>();
 
                 return this;
             }

--- a/src/prometheus-net.DotNetRuntime/EventListening/Parsers/NameResolutionEventParser.cs
+++ b/src/prometheus-net.DotNetRuntime/EventListening/Parsers/NameResolutionEventParser.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Diagnostics.Tracing;
+
+namespace Prometheus.DotNetRuntime.EventListening.Parsers
+{
+    public class NameResolutionEventParser : EventCounterParserBase<NameResolutionEventParser>, NameResolutionEventParser.Events.CountersV5_0
+    {
+
+#pragma warning disable CS0067
+        [CounterName("dns-lookups-requested")]
+        public event Action<MeanCounterValue> DnsLookupsRequested;
+
+        [CounterName("dns-lookups-duration")]
+        public event Action<MeanCounterValue> DnsLookupsDuration;
+#pragma warning restore CS0067
+
+        public override string EventSourceName => "System.Net.NameResolution";
+
+        public static class Events
+        {
+            public interface CountersV5_0 : ICounterEvents
+            {
+                event Action<MeanCounterValue> DnsLookupsRequested;
+                event Action<MeanCounterValue> DnsLookupsDuration;
+            }
+        }
+    }
+}

--- a/src/prometheus-net.DotNetRuntime/Metrics/Producers/NameResolutionMetricProducer.cs
+++ b/src/prometheus-net.DotNetRuntime/Metrics/Producers/NameResolutionMetricProducer.cs
@@ -1,0 +1,42 @@
+﻿using Prometheus.DotNetRuntime.EventListening.Parsers;
+
+namespace Prometheus.DotNetRuntime.Metrics.Producers
+{
+    public class NameResolutionMetricProducer : IMetricProducer
+    {
+        private readonly Consumes<NameResolutionEventParser.Events.CountersV5_0> _nameResolutionCounter;
+
+        public NameResolutionMetricProducer(Consumes<NameResolutionEventParser.Events.CountersV5_0> nameResolutionCounter)
+        {
+            _nameResolutionCounter = nameResolutionCounter;
+        }
+        
+        public void RegisterMetrics(MetricFactory metrics)
+        {
+            if (!_nameResolutionCounter.Enabled)
+                return;
+
+            DnsLookups = metrics.CreateCounter("dotnet_dns_lookups_total", "The number of DNS lookups requested since the process started");
+            var lastLookups = 0.0;
+            _nameResolutionCounter.Events.DnsLookupsRequested += e =>
+            {
+                DnsLookups.Inc(e.Mean - lastLookups);
+                lastLookups = e.Mean;
+            };
+
+            DnsLookupDuration = metrics.CreateHistogram("dotnet_dns_lookup_duration_avg_seconds", "The average time taken for a DNS lookup");
+            _nameResolutionCounter.Events.DnsLookupsDuration += e =>
+            {
+                // Convert milliseconds to seconds
+                DnsLookupDuration.Observe(e.Mean / 1000.0);
+            };
+        }
+
+        internal Histogram DnsLookupDuration { get; private set; }
+        internal Counter DnsLookups { get; private set; }
+
+        public void UpdateMetrics()
+        {
+        }
+    }
+}

--- a/tools/DocsGenerator/Program.cs
+++ b/tools/DocsGenerator/Program.cs
@@ -36,7 +36,8 @@ namespace DocsGenerator
                 SourceAndConfig.CreateFrom(b => b.WithJitStats(CaptureLevel.Counters, SampleEvery.OneEvent)),
                 SourceAndConfig.CreateFrom(b => b.WithJitStats(CaptureLevel.Verbose, SampleEvery.OneEvent)),
                 SourceAndConfig.CreateFrom(b => b.WithExceptionStats(CaptureLevel.Errors)),
-                SourceAndConfig.CreateFrom(b => b.WithSocketStats())
+                SourceAndConfig.CreateFrom(b => b.WithSocketStats()),
+                SourceAndConfig.CreateFrom(b => b.WithNameResolution())
             };
 
             var assemblyDocs = typeof(DotNetRuntimeStatsBuilder).Assembly.LoadXmlDocumentation();


### PR DESCRIPTION
Adds new metrics on .NET 5+:

- `dotnet_dns_lookups_total`:  The number of DNS lookups requested since the process started
- `dotnet_dns_lookup_duration_avg_seconds`: The average time taken for a DNS lookup