### PR TITLE
Adding the new thread pool adjustment reason (lack of this was causin…

### DIFF
--- a/src/prometheus-net.DotNetRuntime/EventListening/Sources/DotNetRuntimeEventSource.cs
+++ b/src/prometheus-net.DotNetRuntime/EventListening/Sources/DotNetRuntimeEventSource.cs
@@ -221,6 +221,7 @@ namespace Prometheus.DotNetRuntime.EventListening.EventSources
             Stabilizing,
             Starvation,
             ThreadTimedOut,
+            CooperativeBlocking
         }
     }
 }


### PR DESCRIPTION
…g exceptions when discovered)

Fixes https://github.com/djluck/prometheus-net.DotNetRuntime/issues/69. 