### PR TITLE
Use NET5_0_OR_GREATER instead of NET5_0

### DIFF
--- a/examples/AspNetCoreExample/Startup.cs
+++ b/examples/AspNetCoreExample/Startup.cs
@@ -90,7 +90,7 @@ namespace AspNetCoreExample
             }
             
             builder 
-#if NET5_0
+#if NET5_0_OR_GREATER
                 .RecycleCollectorsEvery(_options.RecycleEvery)
 #endif
                 .WithErrorHandler(ex => _logger.LogError(ex, "Unexpected exception occurred in prometheus-net.DotNetRuntime"));

--- a/src/prometheus-net.DotNetRuntime.Tests/EventListening/EventParserTypes.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/EventListening/EventParserTypes.cs
@@ -68,7 +68,7 @@ namespace Prometheus.DotNetRuntime.Tests.EventListening
         }
 #endif
         
-#if NET5_0
+#if NET5_0_OR_GREATER
 
         [Test]
         public void When_Calling_GetEventInterfacesForCurrentRuntime_On_Net50_Then_Returns_Interfaces_For_Net50_Runtime_And_Below()

--- a/src/prometheus-net.DotNetRuntime.Tests/IntegrationTests/JitCompilerTests.cs
+++ b/src/prometheus-net.DotNetRuntime.Tests/IntegrationTests/JitCompilerTests.cs
@@ -102,7 +102,7 @@ namespace Prometheus.DotNetRuntime.Tests.IntegrationTests
             return toConfigure.WithJitStats(CaptureLevel.Counters, SampleEvery.OneEvent);
         }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
         
         [Test]
         public void When_Running_On_NET50_Then_Counts_Of_Methods_Are_Recorded()

--- a/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
+++ b/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsBuilder.cs
@@ -226,7 +226,7 @@ namespace Prometheus.DotNetRuntime
                 return this;
             }
 
-#if NET5_0
+#if NET5_0_OR_GREATER
             /// <summary>
             /// Specifies a custom interval to recycle collectors. Defaults to 1 day.
             /// </summary>

--- a/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsCollector.cs
+++ b/src/prometheus-net.DotNetRuntime/DotNetRuntimeStatsCollector.cs
@@ -201,7 +201,7 @@ namespace Prometheus.DotNetRuntime
             public bool EnabledDebuggingMetrics { get; set; } = false;
 
             public TimeSpan? RecycleListenersEvery { get; set; } =
-#if NET5_0
+#if NET5_0_OR_GREATER
                 TimeSpan.FromDays(1);
 #else
                 null;


### PR DESCRIPTION
@djluck was it intended to disable collector recycling for targets higher than net5? Could we just use NET5_0_OR_GREATER instead of NET5_0, so that we keep the recycling feature for net6 (and higher)?